### PR TITLE
Disable tab

### DIFF
--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -54,6 +54,10 @@ lvim.autocommands = {
   _markdown = {
     { "FileType", "markdown", "setlocal wrap" },
     { "FileType", "markdown", "setlocal spell" },
+    { "FileType", "markdown", "map <Tab> <Tab>" },
+    { "FileType", "markdown", "map <S-Tab> <S-Tab>" },
+    { "FileType", "markdown", "imap <Tab> <Tab>" },
+    { "FileType", "markdown", "imap <S-Tab> <S-Tab>" },
   },
   _buffer_bindings = {
     { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },

--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -54,12 +54,9 @@ lvim.autocommands = {
   _markdown = {
     { "FileType", "markdown", "setlocal wrap" },
     { "FileType", "markdown", "setlocal spell" },
-    { "FileType", "markdown", "imap <Tab> <Tab>" },
-    { "FileType", "markdown", "imap <S-Tab> <S-Tab>" },
-    { "FileType", "md", "setlocal wrap" },
-    { "FileType", "md", "setlocal spell" },
-    { "FileType", "md", "imap <Tab> <Tab>" },
-    { "FileType", "md", "imap <S-Tab> <S-Tab>" },
+  },
+  _tab_bindings = {
+    { "FileType", "*", "lua require'core.compe'.set_tab_keybindings()" },
   },
   _buffer_bindings = {
     { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },

--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -54,10 +54,12 @@ lvim.autocommands = {
   _markdown = {
     { "FileType", "markdown", "setlocal wrap" },
     { "FileType", "markdown", "setlocal spell" },
-    { "FileType", "markdown", "map <Tab> <Tab>" },
-    { "FileType", "markdown", "map <S-Tab> <S-Tab>" },
     { "FileType", "markdown", "imap <Tab> <Tab>" },
     { "FileType", "markdown", "imap <S-Tab> <S-Tab>" },
+    { "FileType", "md", "setlocal wrap" },
+    { "FileType", "md", "setlocal spell" },
+    { "FileType", "md", "imap <Tab> <Tab>" },
+    { "FileType", "md", "imap <S-Tab> <S-Tab>" },
   },
   _buffer_bindings = {
     { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },

--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -30,6 +30,8 @@ M.config = function()
       emoji = { kind = " ﲃ  (Emoji)", filetypes = { "markdown", "text" } },
       -- for emoji press : (idk if that in compe tho)
     },
+    -- FileTypes in this list won't trigger auto-complete when TAB is pressed.  Hitting TAB will insert a tab character
+    exclude_filetypes = { "md", "markdown", "mdown", "mkd", "mkdn", "mdwn", "text", "txt" },
   }
 end
 
@@ -88,12 +90,9 @@ M.setup = function()
   vim.api.nvim_set_keymap("i", "<C-d>", "compe#scroll({ 'delta': -4 })", { noremap = true, silent = true, expr = true })
 end
 
-local is_text_file = function(file_type)
-  local text_file_types = { "md", "markdown", "mdown", "mkd", "mkdn", "mdwn", "text", "txt" }
-  print(file_type)
-  for _, type in ipairs(text_file_types) do
+local is_excluded = function(file_type)
+  for _, type in ipairs(lvim.builtin.compe.exclude_filetypes) do
     if type == file_type then
-      print("type is " .. type .. " : filetype is " .. file_type)
       return true
     end
   end
@@ -102,7 +101,7 @@ end
 
 M.set_tab_keybindings = function()
   local file_type = vim.fn.expand "%:e"
-  if is_text_file(file_type) == false then
+  if is_excluded(file_type) == false then
     vim.api.nvim_buf_set_keymap(0, "i", "<Tab>", "v:lua.tab_complete()", { expr = true })
     vim.api.nvim_buf_set_keymap(0, "s", "<Tab>", "v:lua.tab_complete()", { expr = true })
     vim.api.nvim_buf_set_keymap(0, "i", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })

--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -81,11 +81,6 @@ M.setup = function()
     end
   end
 
-  vim.api.nvim_set_keymap("i", "<Tab>", "v:lua.tab_complete()", { expr = true })
-  vim.api.nvim_set_keymap("s", "<Tab>", "v:lua.tab_complete()", { expr = true })
-  vim.api.nvim_set_keymap("i", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })
-  vim.api.nvim_set_keymap("s", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })
-
   vim.api.nvim_set_keymap("i", "<C-Space>", "compe#complete()", { noremap = true, silent = true, expr = true })
   -- vim.api.nvim_set_keymap("i", "<CR>", "compe#confirm('<CR>')", { noremap = true, silent = true, expr = true })
   vim.api.nvim_set_keymap("i", "<C-e>", "compe#close('<C-e>')", { noremap = true, silent = true, expr = true })
@@ -93,4 +88,25 @@ M.setup = function()
   vim.api.nvim_set_keymap("i", "<C-d>", "compe#scroll({ 'delta': -4 })", { noremap = true, silent = true, expr = true })
 end
 
+local is_text_file = function(file_type)
+  local text_file_types = { "md", "markdown", "mdown", "mkd", "mkdn", "mdwn", "text", "txt" }
+  print(file_type)
+  for _, type in ipairs(text_file_types) do
+    if type == file_type then
+      print("type is " .. type .. " : filetype is " .. file_type)
+      return true
+    end
+  end
+  return false
+end
+
+M.set_tab_keybindings = function()
+  local file_type = vim.fn.expand "%:e"
+  if is_text_file(file_type) == false then
+    vim.api.nvim_buf_set_keymap(0, "i", "<Tab>", "v:lua.tab_complete()", { expr = true })
+    vim.api.nvim_buf_set_keymap(0, "s", "<Tab>", "v:lua.tab_complete()", { expr = true })
+    vim.api.nvim_buf_set_keymap(0, "i", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })
+    vim.api.nvim_buf_set_keymap(0, "s", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })
+  end
+end
 return M


### PR DESCRIPTION
The autocommands did not change the tab mappings correctly.  I tab still triggered autocomplete in markdown files.  I think the autocommand technique could not overwrite the default mappings.

I've done something different here.  I'm no longer setting the tab keybindings in the compe setup.  Instead the mappings are set in a different autocommand
```
  _tab_bindings = {
    { "FileType", "*", "lua require'core.compe'.set_tab_keybindings()" },
  },

```
And this is the content of the set_tab_keybindings function.  Notice I use a function to set a keymapping only for the local buffer. 
```
M.set_tab_keybindings = function()
  local file_type = vim.fn.expand "%:e"
  if is_text_file(file_type) == false then
    vim.api.nvim_buf_set_keymap(0, "i", "<Tab>", "v:lua.tab_complete()", { expr = true })
    vim.api.nvim_buf_set_keymap(0, "s", "<Tab>", "v:lua.tab_complete()", { expr = true })
    vim.api.nvim_buf_set_keymap(0, "i", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })
    vim.api.nvim_buf_set_keymap(0, "s", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })
  end
end

```

I suppose since these are general keybindings, they should no longer be compe's responsibility.  But I don't know.  Feel free to refactor as you like.  